### PR TITLE
Return added at passport.authenticate() callback

### DIFF
--- a/movies-api/routes/auth.js
+++ b/movies-api/routes/auth.js
@@ -33,18 +33,18 @@ function authApi(app) {
     passport.authenticate('basic', function(error, user) {
       try {
         if (error || !user) {
-          next(boom.unauthorized());
+          return next(boom.unauthorized());
         }
 
         req.login(user, { session: false }, async function(error) {
           if (error) {
-            next(error);
+            return next(error);
           }
 
           const apiKey = await apiKeysService.getApiKey({ token: apiKeyToken });
 
           if (!apiKey) {
-            next(boom.unauthorized());
+            return next(boom.unauthorized());
           }
 
           const { _id: id, name, email } = user;


### PR DESCRIPTION
En el callback de passport.authenticate es necesario que si utilizamos next(err) o res.function() agreguemos el return antes segun la documentacion de passport, de lo contrario se sigue ejecutando el callback.
Passport documentation: http://www.passportjs.org/docs/authenticate/