### PR TITLE
Usar return al llamar next callback

### DIFF
--- a/movies-api/routes/auth.js
+++ b/movies-api/routes/auth.js
@@ -27,24 +27,24 @@ function authApi(app) {
     const { apiKeyToken } = req.body;
 
     if (!apiKeyToken) {
-      next(boom.unauthorized('apiKeyToken is required'));
+      return next(boom.unauthorized('apiKeyToken is required'));
     }
 
     passport.authenticate('basic', function(error, user) {
       try {
         if (error || !user) {
-          next(boom.unauthorized());
+          return next(boom.unauthorized());
         }
 
         req.login(user, { session: false }, async function(error) {
           if (error) {
-            next(error);
+            return next(error);
           }
 
           const apiKey = await apiKeysService.getApiKey({ token: apiKeyToken });
 
           if (!apiKey) {
-            next(boom.unauthorized());
+            return next(boom.unauthorized());
           }
 
           const { _id: id, name, email } = user;
@@ -96,7 +96,7 @@ function authApi(app) {
       const { apiKeyToken, ...user } = body;
 
       if (!apiKeyToken) {
-        next(boom.unauthorized('apiKeyToken is required'));
+        return next(boom.unauthorized('apiKeyToken is required'));
       }
 
       try {
@@ -104,7 +104,7 @@ function authApi(app) {
         const apiKey = await apiKeysService.getApiKey({ token: apiKeyToken });
 
         if (!apiKey) {
-          next(boom.unauthorized());
+          return next(boom.unauthorized());
         }
 
         const { _id: id, name, email } = queriedUser;


### PR DESCRIPTION
Usar return al llamar next callback para evitar que siga la ejecucion. En los ultimos callbacks next no es necesario el return (como en el caso de los catch aqui). 
Esto lo note ya que seguia la ejecución y logueaba otros errores de más.

IMPORTANTE: Puede que esto este sucediendo en otros archivos pero aviso aqui!